### PR TITLE
Add peer dependency for AWS SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "apollo-server-caching": "^0.1.2",
     "apollo-server-errors": "^2.0.2",
     "aws-sdk": "^2.328.0"
+  },
+  "peerDependencies": {
+    "aws-sdk": "^2.328.0"
   }
 }


### PR DESCRIPTION
This change is a suggestion to better document the dependency relationship between the `aws-sdk` package and this project, enabling better dependency management in its depdendees.

This dependency arises from the need to pass the an instance of the `AWS.S3` client to `S3DataSource` [constructor](https://github.com/ovotech/apollo-datasource-s3/blob/master/src/S3DataSource.ts#L9).